### PR TITLE
Changed where fade-slide-in is applied

### DIFF
--- a/src/DeskHelper.Blazor/Pages/Index.razor
+++ b/src/DeskHelper.Blazor/Pages/Index.razor
@@ -4,7 +4,7 @@
 <div class="container-fluid-md container-lg">
     @if (_computerInfo is null)
     {
-        <div class="row pt-2">
+        <div class="row pt-2 fade-slide-in">
             <div class="col">
                 <LoadingCard />
             </div>
@@ -12,7 +12,7 @@
     }
     else
     {
-        <div class="row pt-2">
+        <div class="row pt-2 fade-slide-in">
             <div class="col-xs-12 col-lg-7">
                 <ComputerDetailsCard InputComputerInfo="@_computerInfo" />
             </div>
@@ -24,14 +24,14 @@
 
         @if (_computerInfo.AzureAdInfo is not null)
         {
-            <div class="row pt-2">
+            <div class="row pt-2 fade-slide-in">
                 <div class="col">
                     <AzureAdInfoCard InputAzureAdInfo="@_computerInfo.AzureAdInfo" />
                 </div>
             </div>
         }
 
-        <div class="row pt-2 pb-3">
+        <div class="row pt-2 pb-3 fade-slide-in">
             <div class="col">
                 <NetworkAdaptersCard InputNetworkAdapters="@_computerInfo.NetworkAdapters" />
             </div>

--- a/src/DeskHelper.Blazor/components/AzureAdInfo/AzureAdInfoCard.razor
+++ b/src/DeskHelper.Blazor/components/AzureAdInfo/AzureAdInfoCard.razor
@@ -2,7 +2,7 @@
 
 @inherits ComponentBase
 
-<div class="card shadow fade-slide-in">
+<div class="card shadow">
     <h2 class="card-header">
         Azure AD details
     </h2>

--- a/src/DeskHelper.Blazor/components/ComputerDetails/ComputerDetailsCard.razor
+++ b/src/DeskHelper.Blazor/components/ComputerDetails/ComputerDetailsCard.razor
@@ -2,7 +2,7 @@
 
 @inherits ComponentBase
 
-<div class="card shadow fade-slide-in">
+<div class="card shadow">
     <h2 class="card-header">
         Computer details
     </h2>

--- a/src/DeskHelper.Blazor/components/NetworkAdapters/NetworkAdaptersCard.razor
+++ b/src/DeskHelper.Blazor/components/NetworkAdapters/NetworkAdaptersCard.razor
@@ -2,7 +2,7 @@
 
 @inherits ComponentBase
 
-<div class="card shadow fade-slide-in">
+<div class="card shadow">
     <h2 class="card-header">
         Network adapters
     </h2>


### PR DESCRIPTION
Instead of the fade slide-in animation running on each individual card
on the index page, it will now apply to each row. Should help with
maintaining consistency.
